### PR TITLE
Adjust prorwts2 settings to preserve screen holes

### DIFF
--- a/prorwts2.a
+++ b/prorwts2.a
@@ -75,10 +75,10 @@ ver_02 = 1
                 detect_err   = 0        ;set to 1 to to detect errors in no_interrupts mode
                 swap_zp      = 0        ;set to 1 to include code to preserve zpage
                                         ;used only by RWTS mode
-                swap_scrn    = 0        ;set to 1 to preserve screen hole contents across SmartPort calls
+                swap_scrn    = 1        ;set to 1 to preserve screen hole contents across SmartPort calls
                                         ;recommended if allow_aux is used, to avoid device reset
                                         ;requires 64 bytes to save all holes
-                read_scrn    = 0        ;set to 1 to support reading into screen memory
+                read_scrn    = 1        ;set to 1 to support reading into screen memory
                                         ;requires swap_scrn
                 rwts_mode    = 0        ;set to 1 to enable emulation of DOS RWTS when running from hard disk
                                         ;uses a one-time open of a tree file, no other file access allowed


### PR DESCRIPTION
Fixes #2 

With MAME e.g. `mame64 apple2ee -sl7 cffa2 -hard1 VIDS.hdv`; select a video e.g. `MTV.LOGO`; once it is playing hit <kbd>Esc</kbd>

Before: Bitsy Bye can't find S7D1 any more.

After: Bitsy Bye shows S7D1 contents correctly.